### PR TITLE
Add LLM Pulse MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Instead of writing custom code for every combination of AI agent and sales tool,
 
 ### 9. Data Analytics & Reporting for Sales
 
+- [llmpulse-mcp (LLM Pulse)](https://github.com/LLM-Pulse/llmpulse-mcp) - Tracks AI search visibility, citations, sentiment, and share of voice for B2B reporting.
 - [server-postgres (modelcontextprotocol)](https://github.com/modelcontextprotocol/servers) - Standard PostgreSQL MCP server for executing queries and schema discovery. ⭐
 - [mcp-sqlite (jparkerweb)](https://github.com/jparkerweb/mcp-sqlite) - Comprehensive MCP server designed for SQLite database interaction.
 - [mcp-clickhouse (ClickHouse)](https://github.com/ClickHouse/mcp-clickhouse) - Official ClickHouse database connector for querying enterprise analytics warehouses.


### PR DESCRIPTION
Adds the official LLM Pulse MCP server to the Data Analytics & Reporting for Sales section.\n\nWhy it fits: LLM Pulse exposes AI search visibility, citations, sentiment, and share-of-voice analytics that sales and growth teams can use in reporting workflows.\n\nVerification:\n- Public repository resolves: https://github.com/LLM-Pulse/llmpulse-mcp\n- Hosted MCP endpoint is available at https://api.llmpulse.ai/api/v1/mcp and correctly requires bearer authentication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new MCP server entry to the sales analytics and reporting section.
  * Included a brief description of AI search visibility tracking, covering citations, sentiment, and share of voice for B2B reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->