### PR TITLE
Add Process Street MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Instead of writing custom code for every combination of AI agent and sales tool,
 - [n8n-nodes-mcp (nerding-io)](https://github.com/nerding-io/n8n-nodes-mcp) - Community node enabling n8n workflows to act as an MCP client connecting to external tools.
 - [mcp-n8n-builder (spences10)](https://github.com/spences10/mcp-n8n-builder) - Specialized builder for programmatic n8n workflow construction and deployment.
 - [pipedream (PipedreamHQ)](https://github.com/PipedreamHQ/pipedream/tree/master/modelcontextprotocol) - Seamless bridge to Pipedream's 2,500+ prebuilt APIs and 8,000+ developer actions. ⭐
+- [Process Street MCP Server](https://github.com/process-street/process-street-mcp) - Connects AI agents to Process Street workflows, runs, tasks, users, data sets, and operational records. ⭐
 - [workflows-mcp-server (cyanheads)](https://github.com/cyanheads/workflows-mcp-server) - YAML-based workflow playbook storage and query server.
 - [agent-device (callstackincubator)](https://github.com/callstackincubator/agent-device) - Discovery router and installer CLI for running mobile and desktop automation workflows.
 ### 7. AI Sales Agents & Copilots


### PR DESCRIPTION
## Summary

Adds Process Street's official hosted MCP server to Workflow Automation.

Process Street exposes workflows, workflow runs, tasks, users, data sets, and operational records to compatible AI clients through a hosted Streamable HTTP endpoint at https://mcp.process.st/.

Public repository: https://github.com/process-street/process-street-mcp
Documentation: https://www.process.st/help/docs/mcp-server/
Official Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.process-street%2Fprocess-street-mcp

This is a first-party submission. The entry is one factual line and uses the official marker allowed by the contribution guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Process Street MCP Server to the Workflow Automation resources.
  * Highlighted connections to workflows, runs, tasks, users, data sets, and operational records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->